### PR TITLE
Fix issue #31

### DIFF
--- a/client/main.coffee
+++ b/client/main.coffee
@@ -57,6 +57,7 @@ tools =
     title: 'Freehand drawing'
     down: (e) ->
       return if pointers[e.pointerId]
+      return if e.button == 2 #Don't draw on right-click or pen eraser
       pointers[e.pointerId] = Meteor.apply 'objectNew', [
         room: currentRoom
         type: 'pen'


### PR DESCRIPTION
Two possible ways to go about this: either don't pass right-click events
to tools, or let each tool decide what it will and won't do with
right-click events.  Since we might later want tools that support both
buttons, I went for the latter philosophy, and now the pen down function
returns if button == 2.