### PR TITLE
Add API Endpoint for Creating New Rooms

### DIFF
--- a/server/api.coffee
+++ b/server/api.coffee
@@ -1,23 +1,29 @@
-url = require("url")
+url = require 'url'
 
 apiMethods =
-  "/roomNew" : () ->
+  '/roomNew': (options) ->
     try
-      result = Meteor.call "roomNew",
-        grid: true
-      [200, {ok: true, id: result}]
+      result = Meteor.call 'roomNew',
+        grid: new Boolean options.grid
+      status: 200
+      json:
+        ok: true
+        id: result
+        url: Meteor.absoluteUrl "/r/#{id}"
     catch e
-      [500, {ok: false, "error": "Error creating new room: #{e}"}]
+      status: 500
+      json:
+        ok: false
+        error: "Error creating new room: #{e}"
 
-
-WebApp.connectHandlers.use "/api", (req, res, next) ->
-  url = url.parse req.url, true
-  if apiMethods.hasOwnProperty url.pathname
-    result = apiMethods[url.pathname](url.query, req, res, next)
-    if !res.headersSent
-      res.writeHead result[0], {"Content-type": "application/json"}
-    if !res.writeableEnded
-      res.end JSON.stringify(result[1])
+WebApp.connectHandlers.use '/api', (req, res, next) ->
+  query = url.parse req.url, true
+  if apiMethods.hasOwnProperty query.pathname
+    result = apiMethods[query.pathname] query.searchParams, req, res, next
+    unless res.headersSent
+      res.writeHead result.status, 'Content-type': 'application/json'
+    unless res.writeableEnded
+      res.end JSON.stringify result.json
   else
     res.writeHead 404
-    res.end "Unknown API endpoint: #{url.path}"
+    res.end "Unknown API endpoint: #{query.path}"

--- a/server/api.coffee
+++ b/server/api.coffee
@@ -18,12 +18,13 @@ WebApp.connectHandlers.use '/api', (req, res, next) ->
   url = new URL req.url, Meteor.absoluteUrl()
   if apiMethods.hasOwnProperty url.pathname
     result = apiMethods[url.pathname] url.searchParams, req, res, next
-    unless res.headersSent
-      res.writeHead result.status, 'Content-type': 'application/json'
-    unless res.writeableEnded
-      res.end JSON.stringify result.json
   else
-    res.writeHead 404
-    res.end JSON.stringify
-      ok: false
-      error: "Unknown API endpoint: #{url.pathname}"
+    result =
+      status: 404
+      json:
+        ok: false
+        error: "Unknown API endpoint: #{url.pathname}"
+  unless res.headersSent
+    res.writeHead result.status, 'Content-type': 'application/json'
+  unless res.writeableEnded
+    res.end JSON.stringify result.json

--- a/server/api.coffee
+++ b/server/api.coffee
@@ -5,7 +5,7 @@ apiMethods =
     try
       result = Meteor.call "roomNew",
         grid: true
-      [200, {ok: true, id: "#{result}"}]
+      [200, {ok: true, id: result}]
     catch e
       [500, {ok: false, "error": "Error creating new room: #{e}"}]
 

--- a/server/api.coffee
+++ b/server/api.coffee
@@ -1,7 +1,7 @@
 url = require("url")
 
 apiMethods =
-  "/roomNew" : (query, req, res, next) ->
+  "/roomNew" : () ->
     try
       result = Meteor.call "roomNew",
         grid: true
@@ -13,9 +13,10 @@ apiMethods =
 WebApp.connectHandlers.use "/api", (req, res, next) ->
   url = url.parse req.url, true
   if apiMethods.hasOwnProperty url.pathname
-    [status, out] = apiMethods[url.pathname](url.query, req, res, next)
-    res.writeHead status, {"Content-type": "application/json"}
-    res.end JSON.stringify(out)
+    result = apiMethods[url.pathname](url.query, req, res, next)
+    if result != null
+      res.writeHead result[0], {"Content-type": "application/json"}
+      res.end JSON.stringify(result[1])
   else
     res.writeHead 404
     res.end "Unknown API endpoint: #{url.path}"

--- a/server/api.coffee
+++ b/server/api.coffee
@@ -14,8 +14,9 @@ WebApp.connectHandlers.use "/api", (req, res, next) ->
   url = url.parse req.url, true
   if apiMethods.hasOwnProperty url.pathname
     result = apiMethods[url.pathname](url.query, req, res, next)
-    if result != null
+    if !res.headersSent
       res.writeHead result[0], {"Content-type": "application/json"}
+    if !res.writeableEnded
       res.end JSON.stringify(result[1])
   else
     res.writeHead 404

--- a/server/api.coffee
+++ b/server/api.coffee
@@ -1,22 +1,21 @@
-url = require('url')
+url = require("url")
 
 apiMethods =
   "/roomNew" : (query, req, res, next) ->
-    Meteor.call 'roomNew',
-      grid: true,
-      (error, room) ->
-        if error?
-          res.writeHead 500
-          res.end "Failed to create new room: #{error}"
-        else
-          res.writeHead 200
-          res.end "#{room}"
+    try
+      result = Meteor.call "roomNew",
+        grid: true
+      [200, {id: "#{result}"}]
+    catch e
+      [500, {"error": "Error creating new room: #{e}"}]
 
 
-WebApp.connectHandlers.use '/api', (req, res, next) ->
+WebApp.connectHandlers.use "/api", (req, res, next) ->
   url = url.parse req.url, true
   if apiMethods.hasOwnProperty url.pathname
-    apiMethods[url.pathname](url.query, req, res, next)
+    [status, out] = apiMethods[url.pathname](url.query, req, res, next)
+    res.writeHead status, {"Content-type": "application/json"}
+    res.end JSON.stringify(out)
   else
     res.writeHead 404
     res.end "Unknown API endpoint: #{url.path}"

--- a/server/api.coffee
+++ b/server/api.coffee
@@ -1,0 +1,22 @@
+url = require('url')
+
+apiMethods =
+  "/roomNew" : (query, req, res, next) ->
+    Meteor.call 'roomNew',
+      grid: true,
+      (error, room) ->
+        if error?
+          res.writeHead 500
+          res.end "Failed to create new room: #{error}"
+        else
+          res.writeHead 200
+          res.end "#{room}"
+
+
+WebApp.connectHandlers.use '/api', (req, res, next) ->
+  url = url.parse req.url, true
+  if apiMethods.hasOwnProperty url.pathname
+    apiMethods[url.pathname](url.query, req, res, next)
+  else
+    res.writeHead 404
+    res.end "Unknown API endpoint: #{url.path}"

--- a/server/api.coffee
+++ b/server/api.coffee
@@ -5,9 +5,9 @@ apiMethods =
     try
       result = Meteor.call "roomNew",
         grid: true
-      [200, {id: "#{result}"}]
+      [200, {ok: true, id: "#{result}"}]
     catch e
-      [500, {"error": "Error creating new room: #{e}"}]
+      [500, {ok: false, "error": "Error creating new room: #{e}"}]
 
 
 WebApp.connectHandlers.use "/api", (req, res, next) ->


### PR DESCRIPTION
This is a first attempt at adding an API endpoint for creating new rooms (#49), as well as a more general structure for future API methods, under the assumption that more API endpoints might want to show up later.

In its current form, each endpoint is defined by a function that optionally takes a query string, as well as all of the raw pieces that `WebApp` provides.  Raw access to those objects means that the endpoint can construct its own response if it wants to, or it can return a `[statuscode, object]` pair, from which an appropriate response will be constructed.  This also assumes that each API endpoint is responsible for its own error handling

Then the `roomNew` endpoint is implemented using this structure, which creates a new room and returns its ID.

I'm not sure if this structure actually makes sense, or if there's a better way to do it.  Feedback welcome!