### PR TITLE
Delete key -> delete selection

### DIFF
--- a/client/main.coffee
+++ b/client/main.coffee
@@ -608,6 +608,19 @@ class Selection
     for id of @selected
       return true
     false
+  erase: ->
+    removedObjects = []
+    for id in @ids()
+      removedObjects.push Objects.findOne id
+      Meteor.call 'objectDel', id
+    if removedObjects.length?
+      undoableOp
+        type: 'multi'
+        ops:
+          for obj in removedObjects
+            type: 'del'
+            obj: obj
+    @clear()
   edit: (attrib, value) ->
     undoableOp
       type: 'multi'
@@ -1194,6 +1207,8 @@ Meteor.startup ->
         when 'y', 'Y'
           if e.ctrlKey or e.metaKey
             redo()
+        when 'Delete'
+          selection.erase()
   document.getElementById('roomLinkStyle').innerHTML =
     Meteor.absoluteUrl 'r/ABCD23456789vwxyz'
   document.getElementById('newRoomLink').setAttribute 'href',

--- a/client/main.coffee
+++ b/client/main.coffee
@@ -615,7 +615,7 @@ class Selection
     undoableOp
       type: 'multi'
       ops:
-        for obj in @ids()
+        for id in @ids()
           obj = Objects.findOne id
           Meteor.call 'objectDel', id
           type: 'del'

--- a/client/main.coffee
+++ b/client/main.coffee
@@ -246,6 +246,7 @@ tools =
       h = pointers[e.pointerId]
       h?.clear()
       if h?.deleted?.length
+        ## The following is similar to Selection.delete:
         undoableOp
           type: 'multi'
           ops:
@@ -608,18 +609,17 @@ class Selection
     for id of @selected
       return true
     false
-  erase: ->
-    removedObjects = []
-    for id in @ids()
-      removedObjects.push Objects.findOne id
-      Meteor.call 'objectDel', id
-    if removedObjects.length?
-      undoableOp
-        type: 'multi'
-        ops:
-          for obj in removedObjects
-            type: 'del'
-            obj: obj
+  delete: ->
+    return unless @nonempty()
+    ## The following is similar to eraser.up:
+    undoableOp
+      type: 'multi'
+      ops:
+        for obj in @ids()
+          obj = Objects.findOne id
+          Meteor.call 'objectDel', id
+          type: 'del'
+          obj: obj
     @clear()
   edit: (attrib, value) ->
     undoableOp
@@ -1207,8 +1207,8 @@ Meteor.startup ->
         when 'y', 'Y'
           if e.ctrlKey or e.metaKey
             redo()
-        when 'Delete'
-          selection.erase()
+        when 'Delete', 'Backspace'
+          selection.delete()
   document.getElementById('roomLinkStyle').innerHTML =
     Meteor.absoluteUrl 'r/ABCD23456789vwxyz'
   document.getElementById('newRoomLink').setAttribute 'href',


### PR DESCRIPTION
This allows deleting all selected objects by hitting the 'Delete' key, which I think could be a nice QoL improvement.

There's probably a way to refactor this so that the `selection.erase` and `eraser.up` share more code, but there is _just_ enough difference between those things that I wasn't sure it was worth doing.