### PR TITLE
Add xlink:href to exported images for Inkscape

### DIFF
--- a/client/tools/download.coffee
+++ b/client/tools/download.coffee
@@ -102,8 +102,7 @@ defineTool
       return match unless image?
       match
       .replace ///crossorigin="([^"]*)"///, ''
-      .replace ///href="(https?://[^"]*)"///,
-        "href=\"#{image}\" xlink:href=\"#{image}\""
+      .replace ///href="(https?://[^"]*)"///, "xlink:href=\"#{image}\""
     ## Download file
     if download
       download = document.getElementById 'download'

--- a/client/tools/download.coffee
+++ b/client/tools/download.coffee
@@ -57,7 +57,7 @@ defineTool
     height = bbox.max.y - bbox.min.y
     svg = """
       <?xml version="1.0" encoding="utf-8"?>
-      <svg xmlns="#{dom.SVGNS}" viewBox="#{bbox.min.x} #{bbox.min.y} #{width} #{height}" width="#{width}px" height="#{height}px">
+      <svg xmlns="#{dom.SVGNS}" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="#{bbox.min.x} #{bbox.min.y} #{width} #{height}" width="#{width}px" height="#{height}px">
       <style>
       .grid { stroke-width: 0.96; stroke: #c4e3f4 }
       #{fonts}</style>

--- a/client/tools/download.coffee
+++ b/client/tools/download.coffee
@@ -99,10 +99,10 @@ defineTool
     count = 0
     svg = svg.replace ///<image\b([^<>]*)>///g, (match, attrs) ->
       image = images[count++]
-      return match unless image?
       match
       .replace ///crossorigin="([^"]*)"///, ''
-      .replace ///href="(https?://[^"]*)"///, "xlink:href=\"#{image}\""
+      .replace ///href="([^"]*)"///, (href, url) ->
+        "xlink:href=\"#{image ? url}\""
     ## Download file
     if download
       download = document.getElementById 'download'

--- a/client/tools/download.coffee
+++ b/client/tools/download.coffee
@@ -102,7 +102,8 @@ defineTool
       return match unless image?
       match
       .replace ///crossorigin="([^"]*)"///, ''
-      .replace ///href="(https?://[^"]*)"///, "href=\"#{image}\""
+      .replace ///href="(https?://[^"]*)"///,
+        "href=\"#{image}\" xlink:href=\"#{image}\""
     ## Download file
     if download
       download = document.getElementById 'download'


### PR DESCRIPTION
Inkscape does not respect the `href` attribute on `<image>` elements, so it is necessary to add the `xlink:href` attribute for images to be displayed properly in Inkscape.