### PR TITLE
Allow panning with middle click and drag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ To see every change with descriptions aimed at developers, see
 As a continuously updated web app, Cocreate uses dates
 instead of version numbers.
 
+## 2021-04-25
+
+* You can now pan the page around without switching to Pan mode
+  by dragging with the middle mouse button (in addition to the previous
+  method of dragging while holding <kbd>Spacebar</kbd>).
+  [[#174](https://github.com/edemaine/cocreate/issues/178)]
+* Middle click shouldn't accidentally paste on Linux anymore.
+  [[#166](https://github.com/edemaine/cocreate/issues/166)]
+
 ## 2021-04-24
 
 * Time Travel is now a toggle/overlay mode supporting both Pan and Select

--- a/client/DrawApp.coffee
+++ b/client/DrawApp.coffee
@@ -169,6 +169,9 @@ export DrawApp = React.memo ->
         ## Prevent right click from bringing up context menu, as it interferes
         ## with e.g. drawing.
         e.preventDefault()
+      auxclick: (e) ->
+        ## Prevent middle click from pasting in X-windows.
+        e.preventDefault()
       wheel: (e) ->
         e.preventDefault()
         transform = currentBoard().transform

--- a/client/DrawApp.coffee
+++ b/client/DrawApp.coffee
@@ -134,12 +134,19 @@ export DrawApp = React.memo ->
 
   ## Pointer event handlers used on both boards
   useEffect ->
+    middleDown = false
+    oldPointers = null
     dom.listen [mainBoardRef.current, historyBoardRef.current],
       pointerdown: (e) ->
         e.preventDefault()
         return if restrictTouch e
         text.blur() for text in document.querySelectorAll 'input'
         window.focus()  # for getting keyboard focus when <iframe>d
+        if e.button == 1 and currentTool.get() != 'pan'
+          middleDown = true
+          oldPointers = {}
+          oldPointers[key] = pointers[key] for own key of pointers
+          selectTool 'pan', noStop: true
         tools[currentTool.get()].down? e
       pointerenter: (e) ->
         e.preventDefault()
@@ -149,6 +156,10 @@ export DrawApp = React.memo ->
         e.preventDefault()
         return if restrictTouch e
         tools[currentTool.get()].up? e
+        if e.button == 1 and middleDown
+          selectTool lastTool, noStart: true
+          pointers[key] = oldPointers[key] for own key of oldPointers
+          middleDown = false
       pointerleave: stop
       pointermove: (e) ->
         e.preventDefault()

--- a/client/tools/modes.coffee
+++ b/client/tools/modes.coffee
@@ -31,7 +31,7 @@ defineTool
   icon: 'arrows-alt'
   hotspot: [0.5, 0.5]
   help: 'Pan around the page by dragging'
-  hotkey: 'hold SPACE'
+  hotkey: 'hold SPACE or middle mouse button'
   down: (e) ->
     board = currentBoard()
     pointers[e.pointerId] = board.eventToRawPoint e

--- a/client/tools/tools.coffee
+++ b/client/tools/tools.coffee
@@ -50,7 +50,7 @@ export selectTool = (tool, options) ->
   else
     tool = currentTool.get()
   updateCursor()
-  resumeTool()
+  resumeTool options
   ## Pass previous tool's selection into new tool for possible selection.
   ## Equivalent to `setSelection` at this point because we've already cleared.
   tools[tool]?.select? selected if selected?
@@ -87,3 +87,20 @@ export restrictTouch = (e) ->
   not allowTouch.get() and \
   e.pointerType == 'touch' and \
   currentTool.get() of drawingTools
+
+## Temporary tool activation, intended for excursions into 'pan' tool
+
+export pushTool = (tool) ->
+  oldTool = currentTool.get()
+  oldPointers = Object.assign {}, pointers
+  ## Leave existing pointer data for updating selection
+  #delete pointers[key] for key of pointers
+  selectTool tool, noStop: true
+  {oldTool, oldPointers}
+
+export popTool = ({oldTool, oldPointers}) ->
+  selectTool oldTool, noStart: true
+  ## Reset pointers to old state
+  delete pointers[key] for key of pointers
+  Object.assign pointers, oldPointers
+  null

--- a/doc/README.md
+++ b/doc/README.md
@@ -138,7 +138,8 @@ and it moves around as you'd expect.
 Panning is special because it's accessible in any mode
 by holding down either the <kbd>Space</kbd> key or the middle mouse button
 and then dragging the page.
-(This behavior matches that of many image editing tools.)
+(This behavior combines features common in many drawing tools such as
+Adobe Illustrator, Adobe Photoshop, GIMP, and Inkscape.)
 
 A scroll wheel or a touchpad's scroll gesture (typically
 two-finger dragging) also pans the canvas.

--- a/doc/README.md
+++ b/doc/README.md
@@ -135,9 +135,10 @@ This tool does one thing: scroll around the page.
 To use it, drag the page as you would a physical piece of paper,
 and it moves around as you'd expect.
 
-Panning is special because it's accessible in any mode (if you have a keyboard)
-by holding down the <kbd>Space</kbd> key and then dragging the page.
-(This behavior matches Adobe Creative Suite.)
+Panning is special because it's accessible in any mode
+by holding down either the <kbd>Space</kbd> key or the middle mouse button
+and then dragging the page.
+(This behavior matches that of many image editing tools.)
 
 A scroll wheel or a touchpad's scroll gesture (typically
 two-finger dragging) also pans the canvas.


### PR DESCRIPTION
This replicates similar behavior in e.g. GIMP and Inkscape, and allows
for greater one-handed control (the left hand is no longer occupied with
the spacebar).

I don't know how this interacts with #166, but I'm on X and don't seem
to be experiencing any problems on Firefox or Chromium.