### PR TITLE
Don't consider tool down on pointerenter with button pressed (fix #218)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,21 @@ To see every change with descriptions aimed at developers, see
 As a continuously updated web app, Cocreate uses dates
 instead of version numbers.
 
+## 2022-11-28
+
+* Drawing actions are no longer interrupted when your cursor accidentally
+  leaves the Cocreate window.
+  [[#219](https://github.com/edemaine/cocreate/issues/219)]
+* Moving your cursor into the Cocreate window while you have a button pressed
+  no longer starts a drawing action, fixing behavior on e.g. Chromium on X11
+  with a stylus.
+  [[#218](https://github.com/edemaine/cocreate/issues/218)],
+  [[#219](https://github.com/edemaine/cocreate/issues/219)]
+
 ## 2022-11-21
 
 * Fix anchor drag bugs: dragging non-defining corners of rectangles and
-  ellipses was broken, and moving to old location was accidentally forbidden
+  ellipses was broken, and moving to old location was accidentally forbidden.
   [[#214](https://github.com/edemaine/cocreate/issues/214)]
 * Fix dotted rectangles not rendering
 

--- a/client/DrawApp.coffee
+++ b/client/DrawApp.coffee
@@ -173,8 +173,9 @@ export DrawAppRoom = ->
         tools[currentTool()].down? e
       pointerenter: (e) ->
         e.preventDefault()
-        return tools.multitouch.enter? e if restrictTouchDraw e
-        ## Stop middle-button pan if we re-enter board with button released
+        #return tools.multitouch.enter? e if restrictTouchDraw e
+        ## Stop middle-button pan if we re-enter board with button released.
+        ## (This shouldn't be necessary anymore with setPointerCapture.)
         if middleDown and (e.buttons & 4) == 0
           middleDown = popTool middleDown
         ## The following line allows to start drawing by dragging the cursor

--- a/client/DrawApp.coffee
+++ b/client/DrawApp.coffee
@@ -169,8 +169,8 @@ export DrawAppRoom = ->
         if e.button == 1 and currentTool() != 'pan' and
            not middleDown and not spaceDown
           middleDown = pushTool 'pan'
+        currentBoard()?.svg?.setPointerCapture e.pointerId
         tools[currentTool()].down? e
-        e.target.setPointerCapture e.pointerId
       pointerenter: (e) ->
         e.preventDefault()
         return tools.multitouch.enter? e if restrictTouchDraw e

--- a/client/DrawApp.coffee
+++ b/client/DrawApp.coffee
@@ -170,6 +170,7 @@ export DrawAppRoom = ->
            not middleDown and not spaceDown
           middleDown = pushTool 'pan'
         tools[currentTool()].down? e
+        e.target.setPointerCapture e.pointerId
       pointerenter: (e) ->
         e.preventDefault()
         return tools.multitouch.enter? e if restrictTouchDraw e
@@ -182,13 +183,14 @@ export DrawAppRoom = ->
         ## make us think the mouse button is pressed, even after the stylus is
         ## released.
         # tools[currentTool()].down? e if e.buttons
-      pointerup: stop = (e) ->
+      pointerup: (e) ->
         e.preventDefault()
         return tools.multitouch.up? e if restrictTouchDraw e
         tools[currentTool()].up? e
         if e.button == 1 and middleDown  ## end middle-button pan
           middleDown = popTool middleDown
-      pointerleave: stop
+      pointerleave: (e) ->
+        e.preventDefault()
       pointermove: (e) ->
         e.preventDefault()
         return tools.multitouch.move? e if restrictTouchDraw e

--- a/client/DrawApp.coffee
+++ b/client/DrawApp.coffee
@@ -176,7 +176,12 @@ export DrawAppRoom = ->
         ## Stop middle-button pan if we re-enter board with button released
         if middleDown and (e.buttons & 4) == 0
           middleDown = popTool middleDown
-        tools[currentTool()].down? e if e.buttons
+        ## The following line allows to start drawing by dragging the cursor
+        ## inside the board with the mouse button pressed.
+        ## But on some systems (Chromium on X11), when using a stylus, it can
+        ## make us think the mouse button is pressed, even after the stylus is
+        ## released.
+        # tools[currentTool()].down? e if e.buttons
       pointerup: stop = (e) ->
         e.preventDefault()
         return tools.multitouch.up? e if restrictTouchDraw e


### PR DESCRIPTION
This is intended to fix https://github.com/edemaine/cocreate/issues/218, an issue when using stylus on Chromium on Linux/X11.

The issue is caused by a combination of Chromium's behavior on this platform, and Cocreate treating a pointerenter event with a button pressed as marking the current tool as "down" even in the absence of any pointerdown event.

This commit disables that.

As a (side-)effect, if this commit is applied, one can no longer start to draw by starting dragging the mouse (or finger or stylus) on a Cocreate toolbar and then dragging in into the drawing board. I wouldn't consider this a disimprovement. (Note that if the dragging starts outside the browser window, or even on the browser's toolbars, it wouldn't start drawing even before this commit.) But if you want I can limit the change by platform using the user agent string.